### PR TITLE
画像投稿機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@
 
 .DS_Store
 /vendor/bundle
+
+/public/uploads

--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ gem "tailwindcss-ruby", "3.4.17"
 gem "devise"
 gem "rails-i18n"           # Rails全体の日本語対応（バリデーション、日付など）
 gem "devise-i18n"          # Deviseの翻訳ファイル（エラーメッセージなど）
+
+gem 'carrierwave', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (3.1.2)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
     childprocess (5.1.0)
       logger (~> 1.5)
     concurrent-ruby (1.3.5)
@@ -114,10 +121,21 @@ GEM
       rails-i18n
     drb (2.2.1)
     erubi (1.13.1)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -153,6 +171,9 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (5.2.0)
+      benchmark
+      logger
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -279,6 +300,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.3)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.32.0)
@@ -295,6 +319,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.3.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
@@ -348,6 +373,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  carrierwave (~> 3.0)
   debug
   devise
   devise-i18n

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -45,6 +45,16 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :address, :body, images: [])
+    permitted = params.require(:post).permit(:title, :address, :body, images: [])
+    
+    if permitted[:images].present?
+      # 空ファイルが混ざってる場合は除去
+      permitted[:images].reject!(&:blank?)
+    end
+  
+    permitted.delete(:images) if permitted[:images].blank?
+    
+    permitted
   end
+    
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -45,6 +45,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :address, :body, :image)
+    params.require(:post).permit(:title, :address, :body, images: [])
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,5 +4,5 @@ class Post < ApplicationRecord
 
   belongs_to :user
 
-  mount_uploader :image, ImageUploader
+  mount_uploaders :images, ImageUploader
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,4 +3,6 @@ class Post < ApplicationRecord
   validates :body, presence: true, length: { maximum: 65_535 }
 
   belongs_to :user
+
+  mount_uploader :image, ImageUploader
 end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,0 +1,16 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+  # アップロードされたファイルの保存ディレクトリ
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # ファイルがアップロードされていないときのデフォルト画像
+  def default_url
+    'sample.jpg' # publicディレクトリ配下のパスが対象（例: public/sample.jpg）
+  end
+
+  # 許可する拡張子のホワイトリスト
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,16 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # アップロードされたファイルの保存ディレクトリ
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # ファイルがアップロードされていないときのデフォルト画像
+  def default_url
+    'sample.jpg' # publicディレクトリ配下のパスが対象（例: public/sample.jpg）
+  end
+
+  # 許可する拡張子のホワイトリスト
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
+end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,32 +1,42 @@
 <div class="card bg-base-100 shadow-md hover:shadow-lg transition-shadow duration-300">
-  <div class="card-body space-y-3">
-    
-    <div class="flex justify-between items-end border-b pb-1">
-      <div class="flex flex-col justify-end">
-        <h2 class="text-xl font-semibold leading-tight">
-          <%= link_to post.title, post_path(post), class: "text-blue-600 hover:underline" %>
-        </h2>
-      </div>
+  <div class="flex flex-row">
 
-      <!-- 日付とアイコン群 -->
-      <div class="flex items-center space-x-3 text-sm text-gray-500">
-        <!-- 日付 -->
-        <p>
-          <%= post.created_at.strftime("%Y年%m月%d日 %H:%M") %>
-        </p>
+    <% if post.images.present? && post.images.first.present? %>
+      <!-- 左：画像エリア（高さをカードに揃える） -->
+      <%= link_to post_path(post), class: "w-32 flex-shrink-0 flex items-center justify-center overflow-hidden rounded-l-xl bg-gray-100" do %>
+        <%= image_tag post.images.first.url, class: "max-h-full max-w-full object-cover" %>
+      <% end %>
+    <% end %>
+
+    <!-- 右：テキストエリア -->
+    <div class="p-4 flex flex-col justify-between flex-grow">
+      <div>
+        <h2 class="text-lg font-semibold text-blue-600 hover:underline">
+          <%= link_to post.title, post_path(post) %>
+        </h2>
 
         <!-- 仕切り線 -->
-        <% if user_signed_in? && current_user == post.user %>
-          <div class="h-4 border-l border-gray-300"></div>
+        <div class="border-b border-gray-300 my-2"></div>
 
-          <!-- 編集・削除アイコン -->
+        <!-- 住所 -->
+        <p class="text-sm text-gray-600">
+          <%= post.address %>
+        </p>
+
+        <!-- 本文 -->
+        <p class="text-sm text-gray-700 mt-2">
+          <%= truncate(post.body, length: 60) %>
+        </p>
+      </div>
+
+      <!-- 日付や編集ボタンなど -->
+      <div class="flex justify-between items-center mt-4 text-sm text-gray-500">
+        <p><%= post.created_at.strftime("%Y年%m月%d日 %H:%M") %></p>
+        <% if user_signed_in? && current_user == post.user %>
           <div class="flex items-center space-x-2">
-            <!-- 編集ボタン -->
             <%= link_to edit_post_path(post), class: "hover:text-blue-600 transition" do %>
               <i class="fa-solid fa-pen-to-square"></i>
             <% end %>
-
-            <!-- 削除ボタン（※link_toではなくform_withで対応） -->
             <%= form_with url: post_path(post), method: :delete, class: "inline", data: { turbo_confirm: "本当に削除しますか？" } do %>
               <button type="submit" class="hover:text-red-600 transition">
                 <i class="fa-solid fa-trash"></i>
@@ -36,16 +46,6 @@
         <% end %>
       </div>
     </div>
-
-    <!-- 住所 -->
-    <div class="text-sm text-gray-600">
-      <%= post.address %>
-    </div>
-
-    <!-- レビュー本文 -->
-    <p class="text-base text-gray-800">
-      <%= truncate(post.body, length: 100) %>
-    </p>
 
   </div>
 </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -31,7 +31,7 @@
               <label class="label">
                 <span class="label-text">画像アップロード</span>
               </label>
-              <%= f.file_field :image, class: "file-input file-input-bordered w-full" %>
+              <%= f.file_field :images, multiple: true, class: "file-input file-input-bordered w-full" %>
             </div>
 
             <div class="mt-4">

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -34,6 +34,16 @@
               <%= f.file_field :images, multiple: true, class: "file-input file-input-bordered w-full" %>
             </div>
 
+            <% if @post.images.present? %>
+              <div class="flex space-x-2 mb-4">
+                <% @post.images.each do |img| %>
+                  <div class="w-20 h-20 overflow-hidden rounded">
+                    <%= image_tag img.url, class: "object-cover w-full h-full" %>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+
             <div class="mt-4">
               <%= f.submit "レビューを更新する", class: "btn btn-neutral w-full" %>
             </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -31,7 +31,7 @@
               <label class="label">
                 <span class="label-text">画像アップロード</span>
               </label>
-              <%= f.file_field :image, class: "file-input file-input-bordered w-full" %>
+              <%= f.file_field :images, multiple: true, class: "file-input file-input-bordered w-full" %>
             </div>
 
             <div class="mt-4">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,6 +3,14 @@
     <div class="card bg-base-100 w-full shadow-2xl">
       <div class="card-body space-y-6">
 
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-6">
+          <% @post.images.each do |image| %>
+            <a href="<%= image.url %>" target="_blank" rel="noopener">
+              <img src="<%= image.url %>" alt="投稿画像" class="w-full h-48 object-cover rounded-xl shadow hover:opacity-90 transition" />
+            </a>
+          <% end %>
+        </div>
+
         <!-- タイトル＋投稿日 -->
         <div class="flex justify-between border-b pb-1">
           <div class="flex flex-col justify-end">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -34,9 +34,7 @@
         <!-- レビュー内容 -->
         <div>
           <p class="text-sm font-semibold text-gray-500 mb-1">レビュー内容</p>
-          <p class="text-base text-gray-800 whitespace-pre-line leading-[0.6]">
-            <%= @post.body %>
-          </p>
+          <p class="text-base text-gray-800 whitespace-pre-line leading-relaxed"><%= @post.body %></p>
         </div>
 
         <% if user_signed_in? && current_user == @post.user %>

--- a/db/migrate/20250530133600_add_images_to_posts.rb
+++ b/db/migrate/20250530133600_add_images_to_posts.rb
@@ -1,0 +1,5 @@
+class AddImagesToPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :posts, :images, :json
+  end
+end

--- a/db/migrate/20250530134417_remove_image_from_posts.rb
+++ b/db/migrate/20250530134417_remove_image_from_posts.rb
@@ -1,0 +1,5 @@
+class RemoveImageFromPosts < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :posts, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_23_065621) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_30_134417) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,10 +20,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_23_065621) do
     t.string "address"
     t.float "latitude"
     t.float "longitude"
-    t.string "image"
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "images"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
### 概要
画像投稿機能

### 内容

- [x] gem 'carrierwave'の導入
- [x] uploaderファイル・モデルファイルの編集
- [x] 投稿作成画面・編集画面から画像を複数枚投稿できる
- [x] 投稿一覧ページ・投稿詳細ページにて画像を確認できる
- [x] 編集時に投稿を保持している→何も変更せずに更新すると元の画像がアップされる
- [x] 本番環境でも同様の動作ができる